### PR TITLE
Remove exceptions from deployments scripts

### DIFF
--- a/deploy/203_deploy_connext_facet.ts
+++ b/deploy/203_deploy_connext_facet.ts
@@ -5,7 +5,7 @@ import { ConnextConfig } from '../config/connext';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {
-    deployments: { deploy },
+    deployments: { deploy, log },
     getNamedAccounts,
     ethers,
     network
@@ -13,7 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { from } = await getNamedAccounts();
 
   if (!ConnextConfig[network.name]) {
-    throw new Error("No connext config for this network available: " + network.name);
+    return log("No connext config for this network available: " + network.name)
   }
 
   await deploy('ConnextFacet', {

--- a/deploy/205_deploy_stargate_facet.ts
+++ b/deploy/205_deploy_stargate_facet.ts
@@ -5,7 +5,7 @@ import config from "../config/stargate";
 
 const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
   const {
-    deployments: { deploy },
+    deployments: { deploy, log },
     getNamedAccounts,
     ethers,
     network,
@@ -13,9 +13,7 @@ const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
   const { from } = await getNamedAccounts();
 
   if (!config[network.name]) {
-    throw new Error(
-      "No stargate config for this network available: " + network.name,
-    );
+    return log("No stargate config for this network available: " + network.name);
   }
 
   await deploy("StargateFacet", {

--- a/deploy/206_deploy_hop_facet.ts
+++ b/deploy/206_deploy_hop_facet.ts
@@ -5,7 +5,7 @@ import { HopConfig } from '../config/hop';
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const {
-    deployments: { deploy },
+    deployments: { deploy, log },
     getNamedAccounts,
     ethers,
     network
@@ -13,7 +13,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { from } = await getNamedAccounts();
 
   if (!HopConfig[network.name]) {
-    throw new Error("No config for this network available: " + network.name);
+    return log("No Hop config for this network available: " + network.name);
   }
 
   await deploy('HopFacet', {
@@ -25,9 +25,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hopFacet = await ethers.getContract("HopFacet");
 
   const ABI = ['function initHop(uint256)'];
-  const iface = new hre.ethers.utils.Interface(ABI)
-
-  console.log('HopConfig', HopConfig[network.name]);
+  const iface = new hre.ethers.utils.Interface(ABI);
 
   const initData = iface.encodeFunctionData('initHop', [
     HopConfig[network.name]


### PR DESCRIPTION
Removed exceptions from deployments scripts because once it is thrown it's halting execution of the rest of the scripts