### PR TITLE
Feature/pro 948 replace arbitrum testnet with arbitrum goerli

### DIFF
--- a/config/cBridge.ts
+++ b/config/cBridge.ts
@@ -51,8 +51,4 @@ export const CBridgeConfig = {
     cBridge: "0x6D5862a18C6a169D44d02a8B726a02A5B707B484",
     chainId: 69,
   },
-  [NetworkNames.ArbitrumTest]: {
-    cBridge: "0x8314Af54080dF4d05768c5D3f097f59f170d9564",
-    chainId: 421611,
-  },
 };

--- a/config/stargate.ts
+++ b/config/stargate.ts
@@ -54,10 +54,6 @@ const config: StargateConfig = {
     stargateRouter: "0x817436a076060D158204d955E5403b6Ed0A5fac0",
     chainId: 10009,
   },
-  [NetworkNames.ArbitrumTest]: {
-    stargateRouter: "0x6701D9802aDF674E524053bd44AA83ef253efc41",
-    chainId: 10010,
-  },
   [NetworkNames.OptimismKovan]: {
     stargateRouter: "0xCC68641528B948642bDE1729805d6cf1DECB0B00",
     chainId: 10011,

--- a/extensions/constants.ts
+++ b/extensions/constants.ts
@@ -17,7 +17,6 @@ export enum NetworkNames {
   Aurora = "aurora",
   AuroraTest = "auroraTest",
   Arbitrum = "arbitrum",
-  ArbitrumTest = "arbitrumTest",
   Optimism = "optimism",
   OptimismKovan = "optimismKovan",
   Moonbeam = "moonbeam",
@@ -153,11 +152,6 @@ export const NETWORK_CONFIGS: {
   [NetworkNames.Arbitrum]: {
     chainId: 42161,
     defaultProviderUrl: "https://arb1.arbitrum.io/rpc",
-    defaultGasPrice: 1,
-  },
-  [NetworkNames.ArbitrumTest]: {
-    chainId: 421611,
-    defaultProviderUrl: "https://rinkeby.arbitrum.io/rpc",
     defaultGasPrice: 1,
   },
   [NetworkNames.Optimism]: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@etherspot/contracts",
-  "version": "1.9.51",
+  "version": "1.9.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@etherspot/contracts",
-      "version": "1.9.51",
+      "version": "1.9.52",
       "license": "MIT",
       "devDependencies": {
         "@connext/nxtp-contracts": "0.2.0-beta.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherspot/contracts",
-  "version": "1.9.51",
+  "version": "1.9.52",
   "description": "Etherspot Solidity contracts",
   "keywords": [
     "ether",


### PR DESCRIPTION
## Description
- Removal of `ArbitrumTestnet` as it is now deprecated. `ArbitrumNitro` (Goerli) should be used. There is only one testnet between `ArbitrumOne` and `ArbitrumNova`

## Motivation and Context
- Removal of deprecated testnet.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)